### PR TITLE
Implement JWT validation

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -31,6 +31,7 @@ Ensure all required secrets are set:
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
 - `ENCRYPTION_KEY`
+- `JWT_SECRET`
 
 ### 3. KV Namespaces
 Verify KV namespaces are created and bound correctly.
@@ -113,6 +114,10 @@ wrangler secret put GOOGLE_CLIENT_SECRET
 # Encryption Key (32 characters)
 wrangler secret put ENCRYPTION_KEY
 # Paste your encryption key when prompted
+
+# JWT verification secret
+wrangler secret put JWT_SECRET
+# Paste your JWT secret when prompted
 ```
 
 ### 3.2 Generate Encryption Key

--- a/OAUTH_SETUP.md
+++ b/OAUTH_SETUP.md
@@ -153,6 +153,10 @@ wrangler secret put GOOGLE_CLIENT_SECRET
 # Set encryption key (generate a secure 32-character key)
 wrangler secret put ENCRYPTION_KEY
 # Enter a 32-character encryption key
+
+# Set JWT verification secret
+wrangler secret put JWT_SECRET
+# Enter the JWT secret when prompted
 ```
 
 ### 5.2 Generate Encryption Key

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -4,7 +4,7 @@ This document summarizes suggested improvements for the Google Workspace Remote 
 
 ## Security Improvements
 
-- **Validate Authorization Tokens**: The current validation logic in `src/utils/validation.ts` is a placeholder that simply returns `'user-id'` if the token length is sufficient. Implement proper JWT validation or integrate with Cloudflare Access to verify user identity.
+- **Validate Authorization Tokens**: Tokens are now verified in `src/utils/validation.ts` using HMAC-SHA256 with the `JWT_SECRET` environment variable.
 - **CSRF Protection**: The implementation plan mentions CSRF protection but does not describe a concrete approach. Add state parameter checks and possibly double-submit tokens in the OAuth flow.
 - **Key Rotation**: Document a process for rotating the `ENCRYPTION_KEY` used for token encryption and ensure old tokens are re-encrypted or invalidated.
 - **Scope Minimization**: Ensure that OAuth scopes are restricted to Gmail, Calendar, Drive and People APIs only. Review `OAUTH_SETUP.md` and `IMPLEMENTATION_PLAN.md` to confirm that no additional scopes are requested.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,7 +48,7 @@ When contributing to this project, please follow these security guidelines:
 ### Authentication & Authorization
 - Never commit credentials, tokens, or secrets
 - Use environment variables for sensitive configuration
-- Implement proper token validation (see issue #2)
+- Tokens are validated using the `JWT_SECRET` environment variable
 - Follow OAuth 2.0 best practices
 
 ### Data Protection
@@ -72,7 +72,7 @@ When contributing to this project, please follow these security guidelines:
 ## Known Security Considerations
 
 ### Current Implementation Status
-- **JWT Validation**: Currently using placeholder (see issue #2) - MUST be fixed before production
+- **JWT Validation**: Implemented with HMAC-SHA256 using `JWT_SECRET`
 - **CSRF Protection**: Needs implementation (see issue #3)
 - **Key Rotation**: Process needs documentation (see issue #5)
 

--- a/TECHNICAL_REQUIREMENTS.md
+++ b/TECHNICAL_REQUIREMENTS.md
@@ -103,6 +103,7 @@ globs = ["**/*.js"]
 - `GOOGLE_CLIENT_ID`: OAuth 2.0 client ID
 - `GOOGLE_CLIENT_SECRET`: OAuth 2.0 client secret
 - `ENCRYPTION_KEY`: 32-character encryption key for token storage
+- `JWT_SECRET`: HMAC secret for verifying authorization tokens
 
 ### Worker Variables
 - `ALLOWED_ORIGINS`: Comma-separated list of allowed CORS origins
@@ -330,6 +331,7 @@ interface LogEntry {
 GOOGLE_CLIENT_ID=your_client_id
 GOOGLE_CLIENT_SECRET=your_client_secret
 ENCRYPTION_KEY=32_char_encryption_key_for_dev
+JWT_SECRET=dev_jwt_secret
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 ```
 

--- a/dist/src/utils/validation.js
+++ b/dist/src/utils/validation.js
@@ -1,0 +1,147 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.JWTMalformedError = exports.JWTInvalidSignatureError = exports.JWTNotYetValidError = exports.JWTExpiredError = exports.JWTError = void 0;
+exports.validateRequest = validateRequest;
+exports.validateToolArguments = validateToolArguments;
+const crypto_1 = require("crypto");
+const buffer_1 = require("buffer");
+// Custom error types for JWT validation
+class JWTError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'JWTError';
+    }
+}
+exports.JWTError = JWTError;
+class JWTExpiredError extends JWTError {
+    constructor(message = 'JWT has expired') {
+        super(message);
+        this.name = 'JWTExpiredError';
+    }
+}
+exports.JWTExpiredError = JWTExpiredError;
+class JWTNotYetValidError extends JWTError {
+    constructor(message = 'JWT is not yet valid') {
+        super(message);
+        this.name = 'JWTNotYetValidError';
+    }
+}
+exports.JWTNotYetValidError = JWTNotYetValidError;
+class JWTInvalidSignatureError extends JWTError {
+    constructor(message = 'JWT signature is invalid') {
+        super(message);
+        this.name = 'JWTInvalidSignatureError';
+    }
+}
+exports.JWTInvalidSignatureError = JWTInvalidSignatureError;
+class JWTMalformedError extends JWTError {
+    constructor(message = 'JWT is malformed') {
+        super(message);
+        this.name = 'JWTMalformedError';
+    }
+}
+exports.JWTMalformedError = JWTMalformedError;
+/**
+ * Validates a bearer token using HMAC SHA-256.
+ * The JWT_SECRET environment variable is used as the signing key.
+ * @param authHeader Authorization header value
+ * @param options Validation options
+ * @returns the user id (sub) if valid, otherwise null
+ * @throws {JWTError} When JWT validation fails with specific error types
+ */
+function validateRequest(authHeader, options = {}) {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+        throw new Error('JWT_SECRET not configured');
+    }
+    if (!authHeader.startsWith('Bearer ')) {
+        throw new JWTMalformedError('Authorization header must start with "Bearer "');
+    }
+    const token = authHeader.replace('Bearer ', '');
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+        throw new JWTMalformedError('JWT must have three parts separated by dots');
+    }
+    const [headerB64, payloadB64, signatureB64] = parts;
+    try {
+        // Verify signature
+        const data = `${headerB64}.${payloadB64}`;
+        const expected = (0, crypto_1.createHmac)('sha256', secret).update(data).digest('base64url');
+        if (expected !== signatureB64) {
+            throw new JWTInvalidSignatureError();
+        }
+        // Parse payload
+        const payload = JSON.parse(buffer_1.Buffer.from(payloadB64, 'base64url').toString());
+        const now = Math.floor(Date.now() / 1000);
+        const clockTolerance = options.clockTolerance || 0;
+        // Validate exp claim
+        if (typeof payload.exp === 'number') {
+            if (now >= payload.exp + clockTolerance) {
+                throw new JWTExpiredError(`Token expired at ${new Date(payload.exp * 1000).toISOString()}`);
+            }
+        }
+        // Validate nbf claim (not before)
+        if (typeof payload.nbf === 'number') {
+            if (now < payload.nbf - clockTolerance) {
+                throw new JWTNotYetValidError(`Token not valid until ${new Date(payload.nbf * 1000).toISOString()}`);
+            }
+        }
+        // Validate iat claim (issued at)
+        if (typeof payload.iat === 'number') {
+            if (payload.iat > now + clockTolerance) {
+                throw new JWTNotYetValidError('Token issued in the future');
+            }
+        }
+        // Validate sub claim
+        if (typeof payload.sub !== 'string') {
+            throw new JWTMalformedError('JWT must contain a string "sub" claim');
+        }
+        return payload.sub;
+    }
+    catch (error) {
+        if (error instanceof JWTError) {
+            throw error;
+        }
+        throw new JWTMalformedError('Failed to parse JWT: ' + error.message);
+    }
+}
+function validateToolArguments(tool, args) {
+    const errors = [];
+    if (tool.parameters.required) {
+        for (const required of tool.parameters.required) {
+            if (!(required in args)) {
+                errors.push(`Missing required parameter: ${required}`);
+            }
+        }
+    }
+    for (const [key, value] of Object.entries(args)) {
+        const paramDef = tool.parameters.properties[key];
+        if (!paramDef) {
+            errors.push(`Unknown parameter: ${key}`);
+            continue;
+        }
+        if (!validateType(value, paramDef)) {
+            errors.push(`Invalid type for parameter ${key}`);
+        }
+    }
+    return {
+        valid: errors.length === 0,
+        errors,
+    };
+}
+function validateType(value, schema) {
+    switch (schema.type) {
+        case 'string':
+            return typeof value === 'string';
+        case 'number':
+            return typeof value === 'number';
+        case 'boolean':
+            return typeof value === 'boolean';
+        case 'array':
+            return Array.isArray(value);
+        case 'object':
+            return typeof value === 'object' && value !== null && !Array.isArray(value);
+        default:
+            return true;
+    }
+}

--- a/dist/tests/validation.test.js
+++ b/dist/tests/validation.test.js
@@ -1,0 +1,89 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const strict_1 = __importDefault(require("assert/strict"));
+const node_test_1 = require("node:test");
+const validation_1 = require("../src/utils/validation");
+const crypto_1 = require("crypto");
+const buffer_1 = require("buffer");
+function signToken(payload, secret) {
+    const header = { alg: 'HS256', typ: 'JWT' };
+    const headerB64 = buffer_1.Buffer.from(JSON.stringify(header)).toString('base64url');
+    const payloadB64 = buffer_1.Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const data = `${headerB64}.${payloadB64}`;
+    const signature = (0, crypto_1.createHmac)('sha256', secret).update(data).digest('base64url');
+    return `${headerB64}.${payloadB64}.${signature}`;
+}
+(0, node_test_1.test)('validateRequest returns user id for valid token', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const token = signToken({ sub: 'user1', exp: Math.floor(Date.now() / 1000) + 60 }, 'testsecret');
+    const header = `Bearer ${token}`;
+    strict_1.default.equal((0, validation_1.validateRequest)(header), 'user1');
+});
+(0, node_test_1.test)('validateRequest throws JWTInvalidSignatureError for invalid signature', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const token = signToken({ sub: 'user1', exp: Math.floor(Date.now() / 1000) + 60 }, 'wrong');
+    const header = `Bearer ${token}`;
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(header), validation_1.JWTInvalidSignatureError);
+});
+(0, node_test_1.test)('validateRequest throws JWTExpiredError for expired token', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const token = signToken({ sub: 'user1', exp: Math.floor(Date.now() / 1000) - 10 }, 'testsecret');
+    const header = `Bearer ${token}`;
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(header), validation_1.JWTExpiredError);
+});
+(0, node_test_1.test)('validateRequest validates nbf claim', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const futureTime = Math.floor(Date.now() / 1000) + 60;
+    const token = signToken({ sub: 'user1', nbf: futureTime }, 'testsecret');
+    const header = `Bearer ${token}`;
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(header), validation_1.JWTNotYetValidError);
+});
+(0, node_test_1.test)('validateRequest accepts valid nbf claim', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const pastTime = Math.floor(Date.now() / 1000) - 60;
+    const token = signToken({ sub: 'user1', nbf: pastTime }, 'testsecret');
+    const header = `Bearer ${token}`;
+    strict_1.default.equal((0, validation_1.validateRequest)(header), 'user1');
+});
+(0, node_test_1.test)('validateRequest validates iat claim', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const futureTime = Math.floor(Date.now() / 1000) + 60;
+    const token = signToken({ sub: 'user1', iat: futureTime }, 'testsecret');
+    const header = `Bearer ${token}`;
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(header), validation_1.JWTNotYetValidError);
+});
+(0, node_test_1.test)('validateRequest throws JWTMalformedError for malformed token', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const header = 'Bearer invalid.token';
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(header), validation_1.JWTMalformedError);
+});
+(0, node_test_1.test)('validateRequest throws JWTMalformedError for missing Bearer prefix', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const token = signToken({ sub: 'user1' }, 'testsecret');
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(token), validation_1.JWTMalformedError);
+});
+(0, node_test_1.test)('validateRequest throws JWTMalformedError for missing sub claim', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const token = signToken({ exp: Math.floor(Date.now() / 1000) + 60 }, 'testsecret');
+    const header = `Bearer ${token}`;
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(header), validation_1.JWTMalformedError);
+});
+(0, node_test_1.test)('validateRequest respects clockTolerance option', () => {
+    process.env.JWT_SECRET = 'testsecret';
+    const expiredTime = Math.floor(Date.now() / 1000) - 5;
+    const token = signToken({ sub: 'user1', exp: expiredTime }, 'testsecret');
+    const header = `Bearer ${token}`;
+    // Should throw without tolerance
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(header), validation_1.JWTExpiredError);
+    // Should pass with tolerance
+    strict_1.default.equal((0, validation_1.validateRequest)(header, { clockTolerance: 10 }), 'user1');
+});
+(0, node_test_1.test)('validateRequest throws Error when JWT_SECRET not configured', () => {
+    delete process.env.JWT_SECRET;
+    const token = signToken({ sub: 'user1' }, 'testsecret');
+    const header = `Bearer ${token}`;
+    strict_1.default.throws(() => (0, validation_1.validateRequest)(header), { message: 'JWT_SECRET not configured' });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "google-workspace-remote-mcp",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node --test dist/tests/*.js"
+  }
+}

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,3 @@
+declare var process: {
+  env: Record<string, string | undefined>;
+};

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,0 +1,16 @@
+declare module 'crypto' {
+  export function createHmac(alg: string, key: any): { update(data: any): any; digest(encoding: string): string };
+}
+
+declare module 'buffer' {
+  export const Buffer: any;
+}
+
+declare module 'assert/strict' {
+  const assert: any;
+  export = assert;
+}
+
+declare module 'node:test' {
+  export const test: any;
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,44 +1,116 @@
 import { createHmac } from 'crypto';
 import { Buffer } from 'buffer';
 
+// Custom error types for JWT validation
+export class JWTError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JWTError';
+  }
+}
+
+export class JWTExpiredError extends JWTError {
+  constructor(message = 'JWT has expired') {
+    super(message);
+    this.name = 'JWTExpiredError';
+  }
+}
+
+export class JWTNotYetValidError extends JWTError {
+  constructor(message = 'JWT is not yet valid') {
+    super(message);
+    this.name = 'JWTNotYetValidError';
+  }
+}
+
+export class JWTInvalidSignatureError extends JWTError {
+  constructor(message = 'JWT signature is invalid') {
+    super(message);
+    this.name = 'JWTInvalidSignatureError';
+  }
+}
+
+export class JWTMalformedError extends JWTError {
+  constructor(message = 'JWT is malformed') {
+    super(message);
+    this.name = 'JWTMalformedError';
+  }
+}
+
 /**
  * Validates a bearer token using HMAC SHA-256.
  * The JWT_SECRET environment variable is used as the signing key.
  * @param authHeader Authorization header value
+ * @param options Validation options
  * @returns the user id (sub) if valid, otherwise null
+ * @throws {JWTError} When JWT validation fails with specific error types
  */
-export function validateRequest(authHeader: string): string | null {
+export function validateRequest(
+  authHeader: string,
+  options: { clockTolerance?: number } = {}
+): string | null {
   const secret = process.env.JWT_SECRET;
   if (!secret) {
     throw new Error('JWT_SECRET not configured');
   }
 
+  if (!authHeader.startsWith('Bearer ')) {
+    throw new JWTMalformedError('Authorization header must start with "Bearer "');
+  }
+
   const token = authHeader.replace('Bearer ', '');
   const parts = token.split('.');
   if (parts.length !== 3) {
-    return null;
+    throw new JWTMalformedError('JWT must have three parts separated by dots');
   }
 
   const [headerB64, payloadB64, signatureB64] = parts;
 
   try {
+    // Verify signature
     const data = `${headerB64}.${payloadB64}`;
     const expected = createHmac('sha256', secret).update(data).digest('base64url');
     if (expected !== signatureB64) {
-      return null;
+      throw new JWTInvalidSignatureError();
     }
 
+    // Parse payload
     const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
     const now = Math.floor(Date.now() / 1000);
-    if (typeof payload.exp === 'number' && now >= payload.exp) {
-      return null;
+    const clockTolerance = options.clockTolerance || 0;
+
+    // Validate exp claim
+    if (typeof payload.exp === 'number') {
+      if (now >= payload.exp + clockTolerance) {
+        throw new JWTExpiredError(`Token expired at ${new Date(payload.exp * 1000).toISOString()}`);
+      }
     }
+
+    // Validate nbf claim (not before)
+    if (typeof payload.nbf === 'number') {
+      if (now < payload.nbf - clockTolerance) {
+        throw new JWTNotYetValidError(`Token not valid until ${new Date(payload.nbf * 1000).toISOString()}`);
+      }
+    }
+
+    // Validate iat claim (issued at)
+    if (typeof payload.iat === 'number') {
+      if (payload.iat > now + clockTolerance) {
+        throw new JWTNotYetValidError('Token issued in the future');
+      }
+    }
+
+    // Validate sub claim
     if (typeof payload.sub !== 'string') {
-      return null;
+      throw new JWTMalformedError('JWT must contain a string "sub" claim');
     }
+
     return payload.sub;
-  } catch {
-    return null;
+  } catch (error) {
+    if (error instanceof JWTError) {
+      throw error;
+    }
+    throw new JWTMalformedError('Failed to parse JWT: ' + (error as Error).message);
   }
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,101 @@
+import { createHmac } from 'crypto';
+import { Buffer } from 'buffer';
+
+/**
+ * Validates a bearer token using HMAC SHA-256.
+ * The JWT_SECRET environment variable is used as the signing key.
+ * @param authHeader Authorization header value
+ * @returns the user id (sub) if valid, otherwise null
+ */
+export function validateRequest(authHeader: string): string | null {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET not configured');
+  }
+
+  const token = authHeader.replace('Bearer ', '');
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [headerB64, payloadB64, signatureB64] = parts;
+
+  try {
+    const data = `${headerB64}.${payloadB64}`;
+    const expected = createHmac('sha256', secret).update(data).digest('base64url');
+    if (expected !== signatureB64) {
+      return null;
+    }
+
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+    const now = Math.floor(Date.now() / 1000);
+    if (typeof payload.exp === 'number' && now >= payload.exp) {
+      return null;
+    }
+    if (typeof payload.sub !== 'string') {
+      return null;
+    }
+    return payload.sub;
+  } catch {
+    return null;
+  }
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export interface Tool {
+  parameters: {
+    required?: string[];
+    properties: Record<string, { type: string }>;
+  };
+}
+
+export function validateToolArguments(tool: Tool, args: any): ValidationResult {
+  const errors: string[] = [];
+
+  if (tool.parameters.required) {
+    for (const required of tool.parameters.required) {
+      if (!(required in args)) {
+        errors.push(`Missing required parameter: ${required}`);
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(args)) {
+    const paramDef = tool.parameters.properties[key];
+    if (!paramDef) {
+      errors.push(`Unknown parameter: ${key}`);
+      continue;
+    }
+
+    if (!validateType(value, paramDef)) {
+      errors.push(`Invalid type for parameter ${key}`);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+function validateType(value: any, schema: any): boolean {
+  switch (schema.type) {
+    case 'string':
+      return typeof value === 'string';
+    case 'number':
+      return typeof value === 'number';
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return typeof value === 'object' && value !== null && !Array.isArray(value);
+    default:
+      return true;
+  }
+}

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,6 +1,12 @@
 import assert from 'assert/strict';
 import { test } from 'node:test';
-import { validateRequest } from '../src/utils/validation';
+import {
+  validateRequest,
+  JWTExpiredError,
+  JWTNotYetValidError,
+  JWTInvalidSignatureError,
+  JWTMalformedError,
+} from '../src/utils/validation';
 import { createHmac } from 'crypto';
 import { Buffer } from 'buffer';
 
@@ -20,16 +26,79 @@ test('validateRequest returns user id for valid token', () => {
   assert.equal(validateRequest(header), 'user1');
 });
 
-test('validateRequest returns null for invalid signature', () => {
+test('validateRequest throws JWTInvalidSignatureError for invalid signature', () => {
   process.env.JWT_SECRET = 'testsecret';
   const token = signToken({ sub: 'user1', exp: Math.floor(Date.now() / 1000) + 60 }, 'wrong');
   const header = `Bearer ${token}`;
-  assert.equal(validateRequest(header), null);
+  assert.throws(() => validateRequest(header), JWTInvalidSignatureError);
 });
 
-test('validateRequest returns null for expired token', () => {
+test('validateRequest throws JWTExpiredError for expired token', () => {
   process.env.JWT_SECRET = 'testsecret';
   const token = signToken({ sub: 'user1', exp: Math.floor(Date.now() / 1000) - 10 }, 'testsecret');
   const header = `Bearer ${token}`;
-  assert.equal(validateRequest(header), null);
+  assert.throws(() => validateRequest(header), JWTExpiredError);
+});
+
+test('validateRequest validates nbf claim', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const futureTime = Math.floor(Date.now() / 1000) + 60;
+  const token = signToken({ sub: 'user1', nbf: futureTime }, 'testsecret');
+  const header = `Bearer ${token}`;
+  assert.throws(() => validateRequest(header), JWTNotYetValidError);
+});
+
+test('validateRequest accepts valid nbf claim', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const pastTime = Math.floor(Date.now() / 1000) - 60;
+  const token = signToken({ sub: 'user1', nbf: pastTime }, 'testsecret');
+  const header = `Bearer ${token}`;
+  assert.equal(validateRequest(header), 'user1');
+});
+
+test('validateRequest validates iat claim', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const futureTime = Math.floor(Date.now() / 1000) + 60;
+  const token = signToken({ sub: 'user1', iat: futureTime }, 'testsecret');
+  const header = `Bearer ${token}`;
+  assert.throws(() => validateRequest(header), JWTNotYetValidError);
+});
+
+test('validateRequest throws JWTMalformedError for malformed token', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const header = 'Bearer invalid.token';
+  assert.throws(() => validateRequest(header), JWTMalformedError);
+});
+
+test('validateRequest throws JWTMalformedError for missing Bearer prefix', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const token = signToken({ sub: 'user1' }, 'testsecret');
+  assert.throws(() => validateRequest(token), JWTMalformedError);
+});
+
+test('validateRequest throws JWTMalformedError for missing sub claim', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const token = signToken({ exp: Math.floor(Date.now() / 1000) + 60 }, 'testsecret');
+  const header = `Bearer ${token}`;
+  assert.throws(() => validateRequest(header), JWTMalformedError);
+});
+
+test('validateRequest respects clockTolerance option', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const expiredTime = Math.floor(Date.now() / 1000) - 5;
+  const token = signToken({ sub: 'user1', exp: expiredTime }, 'testsecret');
+  const header = `Bearer ${token}`;
+  
+  // Should throw without tolerance
+  assert.throws(() => validateRequest(header), JWTExpiredError);
+  
+  // Should pass with tolerance
+  assert.equal(validateRequest(header, { clockTolerance: 10 }), 'user1');
+});
+
+test('validateRequest throws Error when JWT_SECRET not configured', () => {
+  delete process.env.JWT_SECRET;
+  const token = signToken({ sub: 'user1' }, 'testsecret');
+  const header = `Bearer ${token}`;
+  assert.throws(() => validateRequest(header), { message: 'JWT_SECRET not configured' });
 });

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,35 @@
+import assert from 'assert/strict';
+import { test } from 'node:test';
+import { validateRequest } from '../src/utils/validation';
+import { createHmac } from 'crypto';
+import { Buffer } from 'buffer';
+
+function signToken(payload: Record<string, any>, secret: string) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const data = `${headerB64}.${payloadB64}`;
+  const signature = createHmac('sha256', secret).update(data).digest('base64url');
+  return `${headerB64}.${payloadB64}.${signature}`;
+}
+
+test('validateRequest returns user id for valid token', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const token = signToken({ sub: 'user1', exp: Math.floor(Date.now() / 1000) + 60 }, 'testsecret');
+  const header = `Bearer ${token}`;
+  assert.equal(validateRequest(header), 'user1');
+});
+
+test('validateRequest returns null for invalid signature', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const token = signToken({ sub: 'user1', exp: Math.floor(Date.now() / 1000) + 60 }, 'wrong');
+  const header = `Bearer ${token}`;
+  assert.equal(validateRequest(header), null);
+});
+
+test('validateRequest returns null for expired token', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const token = signToken({ sub: 'user1', exp: Math.floor(Date.now() / 1000) - 10 }, 'testsecret');
+  const header = `Bearer ${token}`;
+  assert.equal(validateRequest(header), null);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["es2022"],
+    "strict": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- implement real JWT validation logic under `src/utils`
- add tests for validation
- document `JWT_SECRET` secret in docs
- add minimal TS build and test setup

## Testing
- `npm test`