### PR TITLE
Implement JWT issuance in OAuth callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { MCPRequest } from "./mcp/types";
 import { GoogleOAuth } from "./auth/oauth";
 import { TokenStorage } from "./auth/storage";
 import { validateRequest } from "./utils/validation";
+import { createJWT } from "./utils/jwt";
 import { RateLimiter } from "./utils/rate-limit";
 import { Logger } from "./utils/logger";
 import { createState, consumeState } from "./auth/state";
@@ -188,27 +189,11 @@ async function handleOAuthCallback(
       metadata: { success: true },
     });
 
-    return new Response(
-      `
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <title>Authorization Successful</title>
-        <style>
-          body { font-family: system-ui; text-align: center; padding: 50px; }
-          .success { color: #10b981; font-size: 24px; }
-        </style>
-      </head>
-      <body>
-        <div class="success">✓ Authorization successful!</div>
-        <p>You can close this window and return to your application.</p>
-      </body>
-      </html>
-    `,
-      {
-        headers: { "Content-Type": "text/html" },
-      },
-    );
+    const jwt = await createJWT(userId, env.JWT_SECRET, 3600);
+
+    return new Response(JSON.stringify({ token: jwt }), {
+      headers: { "Content-Type": "application/json" },
+    });
   } catch (error) {
     logger.error({
       requestId,

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,40 @@
+export async function createJWT(
+  userId: string,
+  secret: string,
+  expiresInSeconds = 3600,
+): Promise<string> {
+  if (!secret) {
+    throw new Error("JWT_SECRET not configured");
+  }
+
+  const header = { alg: "HS256", typ: "JWT" };
+  const iat = Math.floor(Date.now() / 1000);
+  const payload = { sub: userId, iat, exp: iat + expiresInSeconds };
+
+  const headerB64 = btoa(JSON.stringify(header))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+  const payloadB64 = btoa(JSON.stringify(payload))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+
+  const message = `${headerB64}.${payloadB64}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  const signatureB64 = btoa(String.fromCharCode(...new Uint8Array(signature)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+
+  return `${message}.${signatureB64}`;
+}

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -160,8 +160,9 @@ describe('Main Handler', () => {
       const response = await defaultExport.fetch(request, mockEnv);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get('Content-Type')).toBe('text/html');
-      expect(await response.text()).toContain('Authorization successful!');
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+      const body = await response.json();
+      expect(body.token).toBeDefined();
       expect(mockOAuth.exchangeCodeForTokens).toHaveBeenCalledWith('auth-code');
       expect(mockStorage.storeTokens).toHaveBeenCalled();
     });

--- a/tests/unit/utils/jwt.test.ts
+++ b/tests/unit/utils/jwt.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { createJWT } from '../../../src/utils/jwt';
+import { validateJWT } from '../../../src/utils/validation';
+
+describe('createJWT', () => {
+  const SECRET = 'test-secret-key';
+
+  it('creates a valid JWT that can be validated', async () => {
+    const token = await createJWT('user123', SECRET, 60);
+    const userId = await validateJWT(token, SECRET);
+    expect(userId).toBe('user123');
+  });
+});


### PR DESCRIPTION
## Summary
- issue JWT to client after successful OAuth callback
- add JWT signing helper
- test JWT creation and update OAuth callback tests

## Testing
- `npm run test:run --silent`