### PR TITLE
Fix: Enable authentication flow for Claude Web UI

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -5,9 +5,9 @@
 GOOGLE_CLIENT_ID=your_client_id
 GOOGLE_CLIENT_SECRET=your_client_secret
 
-# 32-character encryption key for token storage
-# Generate with: openssl rand -hex 16
-ENCRYPTION_KEY=32_char_encryption_key_for_dev
+# 32-byte encryption key for token storage (base64 encoded)
+# Generate with: openssl rand -base64 32
+ENCRYPTION_KEY=your_base64_encoded_32_byte_key
 
 # Secret for JWT validation  
 # Generate with: openssl rand -hex 32

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ This is a Cloudflare Worker-based MCP (Model Context Protocol) server that provi
 Required secrets:
 - `GOOGLE_CLIENT_ID`: OAuth client ID
 - `GOOGLE_CLIENT_SECRET`: OAuth client secret
-- `ENCRYPTION_KEY`: 32-character key for token encryption
+- `ENCRYPTION_KEY`: 32-byte key for token encryption (base64 encoded)
 - `JWT_SECRET`: Secret for JWT signing/validation
 - `ALLOWED_ORIGINS`: Comma-separated list of allowed CORS origins
 

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -110,19 +110,25 @@ wrangler secret put GOOGLE_CLIENT_ID
 wrangler secret put GOOGLE_CLIENT_SECRET
 # Paste your client secret when prompted
 
-# Encryption Key (32 characters)
+# Encryption Key (32-byte key, base64 encoded)
 wrangler secret put ENCRYPTION_KEY
-# Paste your encryption key when prompted
+# Paste your base64-encoded encryption key when prompted
 ```
 
 ### 3.2 Generate Encryption Key
 If you need to generate a new encryption key:
+```bash
+# Generate secure 32-byte encryption key
+openssl rand -base64 32
+```
+
+Or using Node.js:
 ```javascript
 // generate-key.js
 const crypto = require('crypto');
-const key = crypto.randomBytes(32).toString('base64').slice(0, 32);
+const key = crypto.randomBytes(32).toString('base64');
 console.log('Encryption Key:', key);
-console.log('Length:', key.length);
+console.log('Key length:', Buffer.from(key, 'base64').length, 'bytes');
 ```
 
 Run:

--- a/OAUTH_SETUP.md
+++ b/OAUTH_SETUP.md
@@ -150,17 +150,24 @@ wrangler secret put GOOGLE_CLIENT_ID
 wrangler secret put GOOGLE_CLIENT_SECRET
 # Enter the client secret when prompted
 
-# Set encryption key (generate a secure 32-character key)
+# Set encryption key (generate a secure 32-byte key)
 wrangler secret put ENCRYPTION_KEY
-# Enter a 32-character encryption key
+# Enter a base64-encoded 32-byte encryption key
 ```
 
 ### 5.2 Generate Encryption Key
+```bash
+# Generate secure 32-byte encryption key
+openssl rand -base64 32
+```
+
+Or using Node.js:
 ```javascript
-// Generate secure encryption key
+// Generate secure 32-byte encryption key
 const crypto = require('crypto');
-const key = crypto.randomBytes(32).toString('base64').slice(0, 32);
+const key = crypto.randomBytes(32).toString('base64');
 console.log('Encryption Key:', key);
+console.log('Key length:', Buffer.from(key, 'base64').length, 'bytes');
 ```
 
 ## Step 6: OAuth Implementation Details

--- a/README.md
+++ b/README.md
@@ -146,6 +146,33 @@ google-workspace-remote-mcp/
 - Connection pooling for SSE streams
 - Lazy loading of tool implementations
 
+## Cloudflare Workers Compatibility
+
+This project is built for Cloudflare Workers with the following considerations:
+
+### Node.js Compatibility
+- Uses `compatibility_date = "2024-09-23"` and `nodejs_compat` flag for Node.js API support
+- The `googleapis` package works via Wrangler's automatic polyfills
+- No native Node.js modules or file system access required
+
+### Runtime Considerations
+- All cryptographic operations use the Web Crypto API
+- Buffer operations are polyfilled automatically by Wrangler
+- Network requests use the Fetch API
+- No long-running processes or WebSocket connections
+
+### Deployment Notes
+- Ensure your `wrangler.toml` includes the `nodejs_compat` compatibility flag
+- The worker bundle size is optimized through tree-shaking
+- KV storage is used for all persistent data (tokens, rate limits)
+- Environment variables and secrets are properly configured
+
+If you encounter compatibility issues during deployment:
+1. Check that `compatibility_date` is set to a recent date
+2. Verify the `nodejs_compat` flag is enabled
+3. Review the Wrangler build output for any bundling warnings
+4. Test thoroughly in the Cloudflare Workers environment
+
 ## Contributing
 
 This is a private project for Jamie's assistant configuration. For similar implementations, reference the patterns and adapt to your needs.

--- a/TECHNICAL_REQUIREMENTS.md
+++ b/TECHNICAL_REQUIREMENTS.md
@@ -102,7 +102,7 @@ globs = ["**/*.js"]
 ### Worker Secrets Required
 - `GOOGLE_CLIENT_ID`: OAuth 2.0 client ID
 - `GOOGLE_CLIENT_SECRET`: OAuth 2.0 client secret
-- `ENCRYPTION_KEY`: 32-character encryption key for token storage
+- `ENCRYPTION_KEY`: 32-byte encryption key for token storage (base64 encoded)
 
 ### Worker Variables
 - `ALLOWED_ORIGINS`: Comma-separated list of allowed CORS origins

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,7 @@ export class MCPServer {
     private env: Env,
     private userId: string,
     private logger: Logger,
+    private isUnauthenticated: boolean = false,
   ) {
     this.tokenManager = new TokenManager(env);
   }
@@ -118,6 +119,25 @@ export class MCPServer {
     }
 
     const tool = this.tools.get(name)!;
+
+    // Check if authentication is required
+    if (this.isUnauthenticated) {
+      // Generate OAuth URL for unauthenticated users
+      const workerUrl = `https://google-workspace-mcp.openshaw.workers.dev`;
+      const authUrl = new URL(`${workerUrl}/oauth/authorize`);
+      authUrl.searchParams.set('user_id', this.userId);
+      
+      return {
+        jsonrpc: "2.0",
+        result: {
+          content: [{
+            type: "text",
+            text: `🔐 Authentication required to use Google Workspace tools.\n\nPlease authenticate by visiting:\n${authUrl.toString()}\n\nOnce authenticated, the tools will be available for use.`
+          }]
+        },
+        id: request.id,
+      };
+    }
 
     // Validate parameters
     const validation = this.validateParameters(args, tool.parameters);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -29,6 +29,7 @@ export class MCPServer {
     private userId: string,
     private logger: Logger,
     private isUnauthenticated: boolean = false,
+    private requestUrl?: string,
   ) {
     this.tokenManager = new TokenManager(env);
   }
@@ -122,9 +123,10 @@ export class MCPServer {
 
     // Check if authentication is required
     if (this.isUnauthenticated) {
-      // Generate OAuth URL for unauthenticated users
-      const workerUrl = `https://google-workspace-mcp.openshaw.workers.dev`;
-      const authUrl = new URL(`${workerUrl}/oauth/authorize`);
+      // Generate OAuth URL using the request origin
+      const requestUrl = this.requestUrl ? new URL(this.requestUrl) : null;
+      const baseUrl = requestUrl ? `${requestUrl.protocol}//${requestUrl.host}` : 'https://your-worker.workers.dev';
+      const authUrl = new URL(`${baseUrl}/oauth/authorize`);
       authUrl.searchParams.set('user_id', this.userId);
       
       return {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -113,6 +113,9 @@ describe('Main Handler', () => {
 
       expect(response.status).toBe(302);
       expect(response.headers.get('Location')).toContain('accounts.google.com');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-XSS-Protection')).toBe('1; mode=block');
       expect(vi.mocked(createState)).toHaveBeenCalledWith(
         mockEnv,
         'test123',
@@ -129,6 +132,9 @@ describe('Main Handler', () => {
 
       expect(response.status).toBe(400);
       expect(await response.text()).toBe('Missing user_id parameter');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-XSS-Protection')).toBe('1; mode=block');
     });
 
     it('should route to OAuth callback endpoint', async () => {
@@ -161,6 +167,9 @@ describe('Main Handler', () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get('Content-Type')).toBe('application/json');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-XSS-Protection')).toBe('1; mode=block');
       const body = await response.json();
       expect(body.token).toBeDefined();
       expect(mockOAuth.exchangeCodeForTokens).toHaveBeenCalledWith('auth-code');

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -197,7 +197,14 @@ describe('Main Handler', () => {
       vi.mocked(RateLimiter).mockImplementation(() => mockRateLimiter as any);
 
       const mockTransport = {
-        getResponse: vi.fn().mockReturnValue(new Response('SSE response')),
+        getResponse: vi.fn().mockImplementation((headers) => {
+          return new Response('SSE response', {
+            headers: {
+              'Content-Type': 'text/event-stream',
+              ...headers
+            }
+          });
+        }),
       };
       vi.mocked(SSETransport).mockImplementation(() => mockTransport as any);
 
@@ -243,9 +250,14 @@ describe('Main Handler', () => {
       vi.mocked(RateLimiter).mockImplementation(() => mockRateLimiter as any);
 
       const mockTransport = {
-        getResponse: vi.fn().mockReturnValue(new Response('SSE response', {
-          headers: { 'Content-Type': 'text/event-stream' }
-        })),
+        getResponse: vi.fn().mockImplementation((headers) => {
+          return new Response('SSE response', {
+            headers: {
+              'Content-Type': 'text/event-stream',
+              ...headers
+            }
+          });
+        }),
       };
       vi.mocked(SSETransport).mockImplementation(() => mockTransport as any);
 
@@ -259,6 +271,11 @@ describe('Main Handler', () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+      // Verify security headers are included
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-XSS-Protection')).toBe('1; mode=block');
+      expect(response.headers.get('Strict-Transport-Security')).toBe('max-age=31536000; includeSubDomains');
       expect(mockServer.initialize).toHaveBeenCalled();
       expect(mockServer.handleRequest).toHaveBeenCalledWith({
         jsonrpc: '2.0',
@@ -323,9 +340,14 @@ describe('Main Handler', () => {
       vi.mocked(RateLimiter).mockImplementation(() => mockRateLimiter as any);
 
       const mockTransport = {
-        getResponse: vi.fn().mockReturnValue(new Response('SSE response', {
-          headers: { 'Content-Type': 'text/event-stream' }
-        })),
+        getResponse: vi.fn().mockImplementation((headers) => {
+          return new Response('SSE response', {
+            headers: {
+              'Content-Type': 'text/event-stream',
+              ...headers
+            }
+          });
+        }),
       };
       vi.mocked(SSETransport).mockImplementation(() => mockTransport as any);
 
@@ -339,6 +361,11 @@ describe('Main Handler', () => {
 
       expect(response.status).toBe(200); // Returns 200 with SSE stream containing auth URL
       expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+      // Verify security headers are included for unauthenticated SSE
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-XSS-Protection')).toBe('1; mode=block');
+      expect(response.headers.get('Strict-Transport-Security')).toBe('max-age=31536000; includeSubDomains');
       // Verify the server was created in unauthenticated mode (5th parameter = true)
       expect(vi.mocked(MCPServer)).toHaveBeenCalledWith(
         expect.anything(), // transport

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -34,5 +34,5 @@ preview_id = "your-rate-limits-preview-id"
 # Set these using wrangler secret put VARIABLE_NAME
 # GOOGLE_CLIENT_ID - From Google Cloud Console
 # GOOGLE_CLIENT_SECRET - From Google Cloud Console  
-# ENCRYPTION_KEY - 32-character key for token encryption
+# ENCRYPTION_KEY - 32-byte key for token encryption (base64 encoded)
 # JWT_SECRET - Secret for JWT validation


### PR DESCRIPTION
## Summary
- Enable MCP server to work with Claude Web UI where custom headers cannot be set
- Maintain backward compatibility with Claude Desktop/CLI JWT authentication

## Changes
- Allow unauthenticated access to `initialize` and `tools/list` methods
- Return OAuth authentication URL when tools are called without authentication
- Support both authenticated and unauthenticated flows
- Generate temporary session IDs for unauthenticated users

## How it works
1. Claude Web UI connects to the MCP server without authentication
2. Server allows discovery of available tools
3. When a tool is used, server returns an OAuth URL
4. User authenticates via the URL
5. Future requests work with the authenticated session

## Testing
- TypeScript compilation passes
- ESLint shows only warnings (no errors)
- Ready for deployment and testing with Claude Web UI

🤖 Generated with [Claude Code](https://claude.ai/code)